### PR TITLE
inverter.cpp: avoid mess with simultaneous read/write operations

### DIFF
--- a/inverter.cpp
+++ b/inverter.cpp
@@ -192,7 +192,7 @@ void cInverter::poll() {
                 ups_qpiws_changed = true;
             }
         }
-
+        if (quit_thread) return;
         sleep(5);
     }
 }

--- a/inverter.h
+++ b/inverter.h
@@ -1,6 +1,7 @@
 #ifndef ___INVERTER_H
 #define ___INVERTER_H
 
+#include <atomic>
 #include <thread>
 #include <mutex>
 
@@ -16,6 +17,8 @@ class cInverter {
 
     std::string device;
     std::mutex m;
+    std::thread t1;
+    std::atomic_bool quit_thread{false};
 
     void SetMode(char newmode);
     bool CheckCRC(unsigned char *buff, int len);
@@ -26,8 +29,11 @@ class cInverter {
         cInverter(std::string devicename);
         void poll();
         void runMultiThread() {
-            std::thread t1(&cInverter::poll, this);
-            t1.detach();
+            t1 = std::thread(&cInverter::poll, this);
+        }
+        void terminateThread() {
+            quit_thread = true;
+            t1.join();
         }
 
         string *GetQpiriStatus();

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <thread>
+#include <sys/file.h>
 
 #include "main.h"
 #include "tools.h"
@@ -160,13 +161,17 @@ int main(int argc, char* argv[]) {
         runOnce = true;
     }
     lprintf("INVERTER: Debug set");
+    const char *settings;
 
     // Get the rest of the settings from the conf file
     if( access( "./inverter.conf", F_OK ) != -1 ) { // file exists
-        getSettingsFile("./inverter.conf");
+        settings = "./inverter.conf";
     } else { // file doesn't exist
-        getSettingsFile("/etc/inverter/inverter.conf");
+        settings = "/etc/inverter/inverter.conf";
     }
+    getSettingsFile(settings);
+    int fd = open(settings, O_RDWR);
+    while (flock(fd, LOCK_EX)) sleep(1);
 
     bool ups_status_changed(false);
     ups = new cInverter(devicename);
@@ -271,6 +276,7 @@ int main(int argc, char* argv[]) {
                 delete reply2;
 
                 if(runOnce) {
+                    ups->terminateThread();
                     // Do once and exit instead of loop endlessly
                     lprintf("INVERTER: All queries complete, exiting loop.");
                     exit(0);
@@ -281,7 +287,9 @@ int main(int argc, char* argv[]) {
         sleep(1);
     }
 
-    if (ups)
+    if (ups) {
+        ups->terminateThread();
         delete ups;
+    }
     return 0;
 }


### PR DESCRIPTION
When many inverter_poller at the same time send commands, the result is undefined.

This locks exclusively the configuration file, while the process is running, so that simultaneous instances have to wait until the file is released.

For some reason locking the device /dev/hidraw0 does not work for me, I get sometimes the output from previous runs.  I suspect that when `cInverter::query()` does exceed the 2s timeout, it quits, and leaves the
response of its commands on the wire.  For fd = /dev/hidraw0: `tcflush(fd, TCOFLUSH);` has no effect.

As a matter of fact, on my system I have increased the timeout in `cInverter::query()` to 15s and now it does always work correctly.

Also the program, when called with -1, could exit, while the thread is receiving data, this leaves the next invocation with some ready-data, which it is not expecting.