### PR TITLE
fix data not printed on oneshot run

### DIFF
--- a/inverter.cpp
+++ b/inverter.cpp
@@ -194,11 +194,12 @@ void cInverter::poll() {
             }
         }
         if (quit_thread) return;
+        sleep(5);
+        // leave after delay for main thread having time to printout data
         if (runOnce) {
             ups_leave = true;
             exit(0);
         }
-        sleep(5);
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -294,8 +294,7 @@ int main(int argc, char* argv[]) {
                 delete reply2;
             }
             
-        }
-        if(ups_leave) {
+        } else if (ups_leave) {
             ups->terminateThread();
             // Do once and exit instead of loop endlessly
             lprintf("INVERTER: All queries complete, exiting loop.");


### PR DESCRIPTION
Sorry you merged so fast, by fixing the infinite loop on oneshot run, I introduced a bug for the one-shot option: loop thread exit right after querying; letting the main thread with no time to retrieve data stored in query buffer. Leaving after the sleep delay in the poll thread resolve the issue. Also I changed the ups_leave test to an else if to prevent an eventual leave without printing data.

I had in hands an inverter to test this out yesterday and it seams to work well now.