### PR TITLE
Add buffersize to parameters

### DIFF
--- a/inverter.cpp
+++ b/inverter.cpp
@@ -8,12 +8,16 @@
 
 #include <termios.h>
 
-cInverter::cInverter(std::string devicename) {
+cInverter::cInverter(std::string devicename, int qpiri, int qpiws, int qmod, int qpigs) {
     device = devicename;
     status1[0] = 0;
     status2[0] = 0;
     warnings[0] = 0;
     mode = 0;
+    qpiri = qpiri;
+    qpiws = qpiws;
+    qmod = qmod;
+    qpigs = qpigs;   
 }
 
 string *cInverter::GetQpigsStatus() {
@@ -152,13 +156,14 @@ bool cInverter::query(const char *cmd, int replysize) {
 
 void cInverter::poll() {
     int n,j;
+    extern const int qpiri, qpiws, qmod, qpigs;
     extern const bool runOnce;
 
     while (true) {
 
         // Reading mode
         if (!ups_qmod_changed) {
-            if (query("QMOD", 5)) {
+            if (query("QMOD", qmod)) {
                 SetMode(buf[1]);
                 ups_qmod_changed = true;
             }
@@ -166,7 +171,7 @@ void cInverter::poll() {
 
         // reading status (QPIGS)
         if (!ups_qpigs_changed) {
-            if (query("QPIGS", 110)) {
+            if (query("QPIGS", qpigs)) {
                 m.lock();
                 strcpy(status1, (const char*)buf+1);
                 m.unlock();
@@ -176,7 +181,7 @@ void cInverter::poll() {
 
         // Reading QPIRI status
         if (!ups_qpiri_changed) {
-            if (query("QPIRI", 97)) {
+            if (query("QPIRI", qpiri)) {
                 m.lock();
                 strcpy(status2, (const char*)buf+1);
                 m.unlock();
@@ -186,7 +191,7 @@ void cInverter::poll() {
 
         // Get any device warnings...
         if (!ups_qpiws_changed) {
-            if (query("QPIWS", 36)) {
+            if (query("QPIWS", qpiws)) {
                 m.lock();
                 strcpy(warnings, (const char*)buf+1);
                 m.unlock();

--- a/inverter.h
+++ b/inverter.h
@@ -26,7 +26,7 @@ class cInverter {
     uint16_t cal_crc_half(uint8_t *pin, uint8_t len);
 
     public:
-        cInverter(std::string devicename);
+        cInverter(std::string devicename, int qpiri, int qpiws, int qmod, int qpigs);
         void poll();
         void runMultiThread() {
             t1 = std::thread(&cInverter::poll, this);

--- a/main.cpp
+++ b/main.cpp
@@ -74,7 +74,6 @@ void attemptAddSetting(float *addTo, string addFrom) {
 void getSettingsFile(string filename) {
 
     try {
-        int buffercount = 0;
         string fileline, linepart1, linepart2;
         ifstream infile;
         infile.open(filename);

--- a/main.cpp
+++ b/main.cpp
@@ -46,6 +46,10 @@ string devicename;
 int runinterval;
 float ampfactor;
 float wattfactor;
+int qpiri = 98;
+int qpiws = 36;
+int qmod = 5;
+int qpigs = 110;
 
 // ---------------------------------------
 
@@ -70,10 +74,10 @@ void attemptAddSetting(float *addTo, string addFrom) {
 void getSettingsFile(string filename) {
 
     try {
+        int buffercount = 0;
         string fileline, linepart1, linepart2;
         ifstream infile;
         infile.open(filename);
-
         while(!infile.eof()) {
             getline(infile, fileline);
             size_t firstpos = fileline.find("#");
@@ -82,7 +86,6 @@ void getSettingsFile(string filename) {
                 size_t delimiter = fileline.find("=");
                 linepart1 = fileline.substr(0, delimiter);
                 linepart2 = fileline.substr(delimiter+1, string::npos - delimiter);
-
                 if(linepart1 == "device")
                     devicename = linepart2;
                 else if(linepart1 == "run_interval")
@@ -91,6 +94,14 @@ void getSettingsFile(string filename) {
                     attemptAddSetting(&ampfactor, linepart2);
                 else if(linepart1 == "watt_factor")
                     attemptAddSetting(&wattfactor, linepart2);
+                else if(linepart1 == "qpiri")
+                    attemptAddSetting(&qpiri, linepart2);
+                else if(linepart1 == "qpiws")
+                    attemptAddSetting(&qpiws, linepart2);
+                else if(linepart1 == "qmod")
+                    attemptAddSetting(&qmod, linepart2);
+                else if(linepart1 == "qpigs")
+                    attemptAddSetting(&qpigs, linepart2);
                 else
                     continue;
             }
@@ -176,7 +187,7 @@ int main(int argc, char* argv[]) {
     while (flock(fd, LOCK_EX)) sleep(1);
 
     bool ups_status_changed(false);
-    ups = new cInverter(devicename);
+    ups = new cInverter(devicename, qpiri, qpiws, qmod, qpigs);
 
     // Logic to send 'raw commands' to the inverter..
     if (!rawcmd.empty()) {


### PR DESCRIPTION
When I first try to retrieve data from my Axpert vm 3k plus I figured out that qpiri answer of my device was not 97 bytes, as set in this code but 98. So I used @ned-kelly code in [this repo](https://github.com/ned-kelly/docker-voltronic-homeassistant/tree/master) and manage to make a use of my device by playing with the buffer size parameters. I suggest to add these changes to the original code, adding default values.

I set qpiri buffer to 98 by default has it work for me but if 97 is a valid value for other type of devices, we can put it back to 97.